### PR TITLE
fix(imports): removing proto messaging imports (goes wrong)

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -104,7 +104,7 @@ client = DatabaseClient('localhost:50051')
 ```python
 # Python
 from messaging_utils.messaging.publishers import Publisher
-from proto_utils.messaging.dtypes import Metadata, ValidationTasks
+from messaging_utils.schemas.validation import Metadata, ValidationTasks
 
 publisher = Publisher()
 task_id = publisher.publish_validation_request(
@@ -112,7 +112,7 @@ task_id = publisher.publish_validation_request(
     file_data=file_content,
     import_name="user_schema_v1",
     metadata=Metadata(filename="data.csv", priority=1),
-    task=ValidationTasks.SAMPLE_VALIDATION
+    task="sample_validation"
 )
 )
 ```

--- a/packages/messaging-utils/README.md
+++ b/packages/messaging-utils/README.md
@@ -75,7 +75,7 @@ Type-safe publishers for different message types:
 
 ```python
 from messaging_utils.messaging.publishers import Publisher
-from proto_utils.messaging.dtypes import Metadata, ValidationTasks
+from messaging_utils.schemas.validation import Metadata
 
 publisher = Publisher()
 
@@ -86,9 +86,10 @@ task_id = publisher.publish_validation_request(
     import_name="user_schema_v1",
     metadata=Metadata(
         filename="data.csv",
-        priority=1
+        content_type="text/csv",
+        size=24
     ),
-    task=ValidationTasks.SAMPLE_VALIDATION
+    task="sample_validation"
 )
 ```
 
@@ -96,7 +97,6 @@ task_id = publisher.publish_validation_request(
 
 ```python
 from messaging_utils.messaging.publishers import Publisher
-from proto_utils.messaging.dtypes import SchemasTasks
 
 publisher = Publisher()
 
@@ -104,7 +104,7 @@ publisher = Publisher()
 task_id = publisher.publish_schema_update(
     routing_key="schema.update",
     import_name="user_schema_v1",
-    task=SchemasTasks.CREATE_SCHEMA,
+    task="upload_schema",
     schema_data=json_schema_dict
 )
 ```

--- a/packages/messaging-utils/messaging-utils-py/src/messaging_utils/core/connection_params.py
+++ b/packages/messaging-utils/messaging-utils-py/src/messaging_utils/core/connection_params.py
@@ -14,42 +14,45 @@ RabbitMQ configuration distributed to clients via the GetMessagingParams
 gRPC endpoint.
 """
 
-from proto_utils.messaging import dtypes
-
 from messaging_utils.core.config import settings
+from messaging_utils.schemas.connection import (
+    AllConnectionParams,
+    ExchangeInfo,
+    QueueInfo,
+)
 
 # Complete messaging parameters configuration for client distribution
-messaging_params: dtypes.GetMessagingParamsResponse = dtypes.GetMessagingParamsResponse(
+messaging_params = AllConnectionParams(
     host=settings.RABBITMQ_HOST,
     port=settings.RABBITMQ_PORT,
     username=settings.RABBITMQ_USER,
     password=settings.RABBITMQ_PASSWORD,
     virtual_host=settings.RABBITMQ_VHOST,
-    exchange=dtypes.ExchangeInfo(
+    exchange=ExchangeInfo(
         exchange=settings.RABBITMQ_EXCHANGE,
         durable=True,
         type=settings.RABBITMQ_EXCHANGE_TYPE,
         queues=[
             # Schema message queue configuration
-            dtypes.QueueInfo(
+            QueueInfo(
                 queue=settings.RABBITMQ_QUEUE_SCHEMAS,
                 routing_key=settings.RABBITMQ_ROUTING_KEY_SCHEMAS,
                 durable=True,
             ),
             # Validation message queue configuration
-            dtypes.QueueInfo(
+            QueueInfo(
                 queue=settings.RABBITMQ_QUEUE_VALIDATIONS,
                 routing_key=settings.RABBITMQ_ROUTING_KEY_VALIDATIONS,
                 durable=True,
             ),
             # Schema results queue configuration
-            dtypes.QueueInfo(
+            QueueInfo(
                 queue=settings.RABBITMQ_QUEUE_RESULTS_SCHEMAS,
                 routing_key=settings.RABBITMQ_ROUTING_KEY_RESULTS_SCHEMAS,
                 durable=True,
             ),
             # Validation results queue configuration
-            dtypes.QueueInfo(
+            QueueInfo(
                 queue=settings.RABBITMQ_QUEUE_RESULTS_VALIDATIONS,
                 routing_key=settings.RABBITMQ_ROUTING_KEY_RESULTS_VALIDATIONS,
                 durable=True,

--- a/packages/messaging-utils/messaging-utils-py/src/messaging_utils/messaging/connection_factory.py
+++ b/packages/messaging-utils/messaging-utils-py/src/messaging_utils/messaging/connection_factory.py
@@ -15,13 +15,13 @@ from typing import Dict, Generator, Optional
 
 import pika
 from pika.adapters.blocking_connection import BlockingChannel
-from proto_utils.messaging.dtypes import (
-    ExchangeInfo,
-    GetMessagingParamsResponse,
-)
 
 from messaging_utils.core.connection_params import messaging_params
-from messaging_utils.schemas.connection import ConnectionParams
+from messaging_utils.schemas.connection import (
+    AllConnectionParams,
+    ConnectionParams,
+    ExchangeInfo,
+)
 
 
 class RabbitMQConnectionFactory:
@@ -49,7 +49,7 @@ class RabbitMQConnectionFactory:
 
     @classmethod
     def configure(
-        cls, connection_params: Optional[GetMessagingParamsResponse] = None
+        cls, connection_params: Optional[AllConnectionParams] = None
     ) -> None:
         """Configure the connection factory with connection parameters.
 

--- a/packages/messaging-utils/messaging-utils-py/src/messaging_utils/messaging/publishers.py
+++ b/packages/messaging-utils/messaging-utils-py/src/messaging_utils/messaging/publishers.py
@@ -15,21 +15,22 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pika
-from proto_utils.messaging.dtypes import (
-    ExchangeInfo,
-    GetMessagingParamsResponse,
-    Metadata,
-    SchemaMessageResponse,
-    SchemasTasks,
-    ValidationMessageResponse,
-    ValidationTasks,
-)
 
 from messaging_utils.core.connection_params import messaging_params
 from messaging_utils.messaging.connection_factory import (
     RabbitMQConnectionFactory,
 )
-from messaging_utils.schemas.connection import ConnectionParams
+from messaging_utils.schemas.connection import (
+    AllConnectionParams,
+    ConnectionParams,
+    ExchangeInfo,
+)
+from messaging_utils.schemas.schemas import SchemaMessage, SchemasTasks
+from messaging_utils.schemas.validation import (
+    Metadata,
+    ValidationMessage,
+    ValidationTasks,
+)
 
 
 class Publisher:
@@ -76,7 +77,7 @@ class Publisher:
             or not RabbitMQConnectionFactory._params
         ):
             RabbitMQConnectionFactory.configure(
-                GetMessagingParamsResponse(
+                AllConnectionParams(
                     **params, exchange=self.exchange_info
                 )
             )
@@ -124,7 +125,7 @@ class Publisher:
         """
         task_id = str(uuid.uuid4())
 
-        message = ValidationMessageResponse(
+        message = ValidationMessage(
             id=task_id,
             task=task,
             file_data=file_data.hex(),
@@ -189,7 +190,7 @@ class Publisher:
         """
         task_id = str(uuid.uuid4())
 
-        message = SchemaMessageResponse(
+        message = SchemaMessage(
             id=task_id,
             schema=schema,
             import_name=import_name,

--- a/packages/messaging-utils/messaging-utils-py/src/messaging_utils/schemas/connection.py
+++ b/packages/messaging-utils/messaging-utils-py/src/messaging_utils/schemas/connection.py
@@ -24,3 +24,7 @@ class ConnectionParams(TypedDict):
     virtual_host: str
     username: str
     password: str
+
+
+class AllConnectionParams(ConnectionParams):
+    exchange: ExchangeInfo

--- a/packages/messaging-utils/messaging-utils-py/src/messaging_utils/schemas/schemas.py
+++ b/packages/messaging-utils/messaging-utils-py/src/messaging_utils/schemas/schemas.py
@@ -1,13 +1,11 @@
-from typing import Dict, Literal, TypedDict
-
-from proto_utils.database.dtypes import JsonSchema
+from typing import Any, Dict, Literal, TypedDict
 
 SchemasTasks = Literal["upload_schema", "remove_schema", "unknown"]
 
 
 class SchemaMessage(TypedDict):
     id: str
-    schema: JsonSchema
+    schema: Dict[str, Any]
     import_name: str
     raw: bool
     tasks: SchemasTasks

--- a/packages/proto-utils/proto-utils-py/src/proto_utils/generated/__init__.py
+++ b/packages/proto-utils/proto-utils-py/src/proto_utils/generated/__init__.py
@@ -16,11 +16,3 @@ from .database.database_pb2 import *
 from .database.database_pb2_grpc import *
 from .database.mongo_pb2 import *
 from .database.redis_pb2 import *
-from .messaging.dtypes_pb2 import *
-from .messaging.dtypes_pb2_grpc import *
-from .messaging.messaging_pb2 import *
-from .messaging.messaging_pb2_grpc import *
-from .messaging.schemas_pb2 import *
-from .messaging.schemas_pb2_grpc import *
-from .messaging.validation_pb2 import *
-from .messaging.validation_pb2_grpc import *


### PR DESCRIPTION
This pull request refactors the messaging utilities to remove dependencies on the `proto_utils` package and standardizes schema and validation message handling. The main changes involve moving type definitions to local `messaging_utils.schemas` modules, updating publisher logic to use these new types, and updating documentation to reflect the new import paths and usage patterns.

**Refactoring to remove proto_utils dependency:**

* Replaced all imports from `proto_utils.messaging.dtypes` with equivalent types from `messaging_utils.schemas.validation`, `messaging_utils.schemas.schemas`, and `messaging_utils.schemas.connection` across the codebase, including in `publishers.py`, `connection_factory.py`, and `connection_params.py` [[1]](diffhunk://#diff-910b16052476e660e2b80f0bff8d28ea155229b7eb020a9a2d69e2186d01104fL17-R55) [[2]](diffhunk://#diff-5979d8716df6ebe9e30253aef8bb1aad0983074820f871486b9381367a60a95cL18-R24) [[3]](diffhunk://#diff-2b4728a98dc291427b387de069764adff31bfce264c055445655a26f9e5ab8c0L18-R33) [[4]](diffhunk://#diff-2b4728a98dc291427b387de069764adff31bfce264c055445655a26f9e5ab8c0L79-R80).

* Introduced new type definitions: `AllConnectionParams`, `ExchangeInfo`, `QueueInfo`, `SchemaMessage`, `ValidationMessage`, `SchemasTasks`, and `ValidationTasks` in the `messaging_utils.schemas` modules to replace proto-based types [[1]](diffhunk://#diff-fe647f4fdcf688b4f5a06c488481b1c106921c935996cb3aa797a600fa3b6d5eR27-R30) [[2]](diffhunk://#diff-879cb49221584a6424472bd851254786d1412e1ce80891306ab8733bad4892fcL1-R8).

**Updates to publisher logic:**

* Updated the `Publisher` class to use the new local schema types for message creation, specifically using `ValidationMessage` and `SchemaMessage` instead of proto-based response types [[1]](diffhunk://#diff-2b4728a98dc291427b387de069764adff31bfce264c055445655a26f9e5ab8c0L127-R128) [[2]](diffhunk://#diff-2b4728a98dc291427b387de069764adff31bfce264c055445655a26f9e5ab8c0L192-R193).

* Changed the `RabbitMQConnectionFactory.configure` method and related logic to use `AllConnectionParams` instead of `GetMessagingParamsResponse` [[1]](diffhunk://#diff-5979d8716df6ebe9e30253aef8bb1aad0983074820f871486b9381367a60a95cL52-R52) [[2]](diffhunk://#diff-2b4728a98dc291427b387de069764adff31bfce264c055445655a26f9e5ab8c0L79-R80) [[3]](diffhunk://#diff-910b16052476e660e2b80f0bff8d28ea155229b7eb020a9a2d69e2186d01104fL17-R55).

**Documentation and usage updates:**

* Updated README examples to use the new import paths and to pass string task names (e.g., `"sample_validation"` and `"upload_schema"`) instead of enum values, and updated `Metadata` usage to match the new schema [[1]](diffhunk://#diff-1206c4b8d1f7e37d1a4079860d4b24c3178398a059b3bd4c0df5c40fabaab45aL107-R115) [[2]](diffhunk://#diff-d18459f1e151b25dc740791bb38dc7dda9b0c963014c0cedcb8f3e2f3bb92684L78-R78) [[3]](diffhunk://#diff-d18459f1e151b25dc740791bb38dc7dda9b0c963014c0cedcb8f3e2f3bb92684L89-R107).

**Schema type adjustments:**

* Modified `SchemaMessage` to use a generic `Dict[str, Any]` for the `schema` field instead of a proto-based `JsonSchema`.

These changes collectively improve maintainability by removing the proto dependency, clarifying type usage, and making the codebase more self-contained.