### PR TITLE
fix(ci): ensure docker build job depends on unit tests

### DIFF
--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -29,6 +29,7 @@ jobs:
 
   docker-build:
     name: Test Docker Build - ${{ inputs.service_name }}
+    needs: unit-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a minor update to the CI workflow configuration. The `docker-build` job now depends on the completion of the `unit-tests` job before it runs, ensuring that Docker builds only proceed if unit tests pass.

* Added `needs: unit-tests` to the `docker-build` job in `.github/workflows/reusable-ci-tests.yml` to enforce job dependency.