### PR TITLE
feat(ci): add installation step for uv in reusable CI tests workflow

### DIFF
--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.22"
       - uses: moonrepo/setup-toolchain@v0
         with:
           auto-install: true


### PR DESCRIPTION
This pull request adds a step to the CI workflow to install the `uv` tool using the `astral-sh/setup-uv` GitHub Action. This ensures that the specified version of `uv` (0.8.22) is available during CI runs.

CI workflow improvements:

* Added a step to install `uv` version 0.8.22 using the `astral-sh/setup-uv@v6` action in `.github/workflows/reusable-ci-tests.yml`.